### PR TITLE
add link to dashboard, fix countdown units bug

### DIFF
--- a/src/landing.html
+++ b/src/landing.html
@@ -1,6 +1,17 @@
 <template>
   <div class="landing-page animated-page container-fluid au-animate">
-    <div class="countdown"><span class="count">${msUntilCanLockCountdown() | timespan:"days" & signal:'secondPassed'}</span>
+    <div
+      class="countdown"
+      if.to-view="(msUntilCanLockCountdown() <= 0) & signal:'secondPassed'"
+    ><a
+        class="count"
+        href="/stake-for-your-vote"
+      >Click here to take part in the dxDAO</a></div>
+
+    <div
+      class="countdown"
+      else
+    ><span class="count">${msUntilCanLockCountdown() | timespan:countdownUnits() & signal:'secondPassed'}</span>
       until you can take part in the dxDAO</div>
 
     <div class="main-header">

--- a/src/landing.ts
+++ b/src/landing.ts
@@ -31,4 +31,11 @@ export class Landing {
   private msUntilCanLockCountdown(): number {
     return this.lockingPeriodStartDate.getTime() - Date.now();
   }
+
+  private countdownUnits(): string {
+    return (this.msUntilCanLockCountdown() >= 86400000) ? 'days' :
+      ((this.msUntilCanLockCountdown() >= 3600000) ? 'hours' :
+        (this.msUntilCanLockCountdown() >= 60000 ? 'minutes' : 'seconds')
+      );
+  }
 }

--- a/static/styles.scss
+++ b/static/styles.scss
@@ -231,6 +231,10 @@ a.text-warning:focus, a.text-warning:hover {
   cursor: pointer;
 }
 
+.hot:hover {
+  text-decoration: underline;
+}
+
 .inline {
   display: inline-block;
 }


### PR DESCRIPTION
* shows link to dashboard when the countdown ends
* when the countdown is less than a day, shows hours; less than an hour, minutes; less than a minute, seconds